### PR TITLE
[COR-4478] Add autogen to opal-go

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,39 @@
+name: Auto Release on PR Merge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all tags
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          default_bump: minor
+
+      - name: Create release
+        run: |
+          gh release create "${{ steps.tag_version.outputs.new_tag }}" \
+            --title "${{ steps.tag_version.outputs.new_version }}" \
+            --generate-notes \
+            --verify-tag \
+            --target "${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autogen-remote-changes.yml
+++ b/.github/workflows/autogen-remote-changes.yml
@@ -1,0 +1,94 @@
+name: Auto-Update SDK
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs everyday at midnight
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  update-sdk:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.24
+
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install OpenAPI Generator CLI
+      run: npm install @openapitools/openapi-generator-cli -g
+
+    - name: Pull and generate SDK
+      run: make gen-openapi-remote-for-ci
+
+    - name: Check for changes
+      id: check_changes
+      run: |
+        if git diff --quiet; then
+          echo "changes=false" >> $GITHUB_ENV
+        else
+          echo "changes=true" >> $GITHUB_ENV
+        fi
+    - name: Set up Git
+      if: env.changes == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+    - name: Commit changes
+      if: env.changes == 'true'
+      run: |
+        BRANCH_NAME="auto-update-sdk-$(date +'%Y-%m-%d-%H-%M-%S')"
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+        git checkout -b $BRANCH_NAME || git checkout $BRANCH_NAME
+        git add .
+        git commit -m "Auto-update SDK on $(date +'%Y-%m-%d')"
+    - name: Push changes
+      if: env.changes == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: git push --force --set-upstream origin $BRANCH_NAME
+    - name: Install GitHub CLI
+      if: env.changes == 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gh
+    - name: Check for existing pull request
+      if: env.changes == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id: check_pr
+      run: |
+        PR_EXISTS=$(gh pr list --search "Auto-update SDK" --base main --state open --json number -q '.[0].number')
+        if [[ -n "$PR_EXISTS" ]]; then
+        echo "pr_exists=true" >> $GITHUB_ENV
+        echo "PR_NUMBER=$PR_EXISTS" >> $GITHUB_ENV
+        else
+        echo "pr_exists=false" >> $GITHUB_ENV
+        fi
+    - name: Create a pull request
+      if: env.changes == 'true' && env.pr_exists == 'false'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        PR_TITLE="Auto-update SDK on $(date +'%Y-%m-%d')"
+        PR_BODY="This pull request was automatically created by GitHub Actions to update the SDK with the latest remote OpenAPI specification."
+        gh pr create --title "$PR_TITLE" --body "$PR_BODY" --head $BRANCH_NAME --base main
+    - name: Update existing pull request
+      if: env.changes == 'true' && env.pr_exists == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "An existing pull request titled 'Auto-update SDK' is already open. Updating it with the latest changes."
+        git push --set-upstream origin $BRANCH_NAME --force
+        gh pr comment $PR_NUMBER --body "This pull request has been updated with the latest changes from the automated SDK update process on $(date +'%Y-%m-%d %H:%M:%S')."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.24
 
     - name: Build
       run: go build -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 SHELL := /bin/bash
 
 OPENAPI_GEN=openapi-generator generate -i api/openapi.yaml -g go -o . -c config.json
+OPENAPI_GEN_CI=openapi-generator-cli generate --enable-post-process-file -i api/openapi.yaml -g go -o . -c config.json
+PULL_REMOTE_OPENAPI=curl https://app.opal.dev/openapi.yaml > api/openapi.yaml
 
 gen-openapi:
 	$(OPENAPI_GEN)
+gen-openapi-remote:
+	$(PULL_REMOTE_OPENAPI)
+	$(OPENAPI_GEN)
+gen-openapi-remote-for-ci:
+	$(PULL_REMOTE_OPENAPI)
+	$(OPENAPI_GEN_CI)


### PR DESCRIPTION
Adds autogen for
- Generating the opal SDK from remote changes to openapi 
- Auto-creating a new release when a PR gets merged from openapi gen